### PR TITLE
Unsigned shell bytecodes

### DIFF
--- a/src/main/java/mtmc/os/shell/Shell.java
+++ b/src/main/java/mtmc/os/shell/Shell.java
@@ -102,10 +102,11 @@ public class Shell {
                     if (result.errors().isEmpty()) {
                         byte[] code = result.code();
                         if (code.length == 4) {
-                            int data = (code[2] << 8) | code[3];
+                            int data = ((code[2] & 0xFF) << 8) | (code[3] & 0xFF);
                             computer.setRegisterValue(Register.DR, data);
                         }
-                        int inst = (code[0] << 8) | code[1];
+                        int inst = ((code[0] & 0xFF) << 8) | (code[1] & 0xFF);
+
                         DebugInfo originalDebugInfo = computer.getDebugInfo();
                         computer.setDebugInfo(result.debugInfo());
                         computer.execInstruction((short) inst);

--- a/src/main/java/mtmc/os/shell/Shell.java
+++ b/src/main/java/mtmc/os/shell/Shell.java
@@ -107,11 +107,9 @@ public class Shell {
                             int data = (higher << 8) | lower;
                             computer.setRegisterValue(Register.DR, data);
                         }
-
                         int lower = code[1] & 0xFF;
                         int higher = code[0] & 0xFF;
                         int inst = (higher << 8) | lower;
-
                         DebugInfo originalDebugInfo = computer.getDebugInfo();
                         computer.setDebugInfo(result.debugInfo());
                         computer.execInstruction((short) inst);


### PR DESCRIPTION
# Using ASM 
The following assembly code runs fine from a compiled file using the `asm` command

```asm
main:
  li a0 7
  li a1 700
  li a2 7
  li a3 700
  sys exit
```

**Output:**
<img width="1021" height="518" alt="Screenshot 2025-07-28 at 9 02 24 AM" src="https://github.com/user-attachments/assets/2fea8d4d-db7a-47cb-9e5b-8d2e13ef88b0" />


# The problem using Shell 

When you input these commands in the shell, the output is different.

* You cannot set any value to registers `a2` and `a3`.
* Any value in any register over 255 shows as a negative number.  

<img width="810" height="558" alt="Screenshot 2025-07-28 at 9 03 06 AM" src="https://github.com/user-attachments/assets/754878d8-32bd-4674-845e-2dfba49b63ff" />


# Debugging

Traced this down to the bytecodes
Command `set a0 7` -> Code `008f 0060` executing instruction:  `ffff8f60` ✅ 
Command `set a1 7` -> Code `008f 0070` executing instruction:  `ffff8f70` ✅ 
Command `set a2 7` -> Code `008f 0080` executing instruction:  `ffffff80` ❌ 

Both the commands and values were not properly masked and flipping over negative when the highest bit was `1`

This PR corrects the issue by masking the values so that they are correctly treated as unsigned. 
