### PR TITLE
Fix spec for the jump register instruction

### DIFF
--- a/docs/MTMC_SPECIFICATION.md
+++ b/docs/MTMC_SPECIFICATION.md
@@ -300,8 +300,8 @@ The MTMC supports one jump command that uses a register as the address to jump t
 
 | Instruction  | Form                  | Description                                    | Example |
 |--------------|-----------------------|------------------------------------------------|---------|
-| `jr`         | `1000 0000 0000 rrrr` | Jumps to the location found in register `rrrr` | `jr ra` |
-| `ret`(alias) | `1000 0000 0000 rrrr` | Alias for `jr ra`                              | `ret`   |
+| `jr`         | `1001 0000 0000 rrrr` | Jumps to the location found in register `rrrr` | `jr ra` |
+| `ret`(alias) | `1001 0000 0000 rrrr` | Alias for `jr ra`                              | `ret`   |
 
 ### JUMPS
 


### PR DESCRIPTION
Jump register is `1001`, as referenced earlier in the spec
https://github.com/msu/mtmc/blob/301477af640bdc56ef2094b2edaabc31bbec78cd/docs/MTMC_SPECIFICATION.md?plain=1#L94

Link https://github.com/msu/mtmc/issues/18#issue-3338650356