### PR TITLE
Display crisp pixels

### DIFF
--- a/src/main/resources/public/css/style.css
+++ b/src/main/resources/public/css/style.css
@@ -191,6 +191,7 @@ main {
 
 #display-img {
     width: 340px;
+    image-rendering: pixelated;
 }
 
 #display-control-wrapper {


### PR DESCRIPTION
Keep the pixels crisp with arbitrary image scaling.
- [CSS image-rendering](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering)

| smoothed | crisp |
| -- | -- |
|<img width="225" src="https://github.com/user-attachments/assets/06203126-a897-4f89-8e6c-23b7f9fdd79e" /> | <img width="225" src="https://github.com/user-attachments/assets/df8333b0-1dd5-44f7-a62e-366f3cdab693" /> |
